### PR TITLE
fix an possible typo error

### DIFF
--- a/binary-search.py
+++ b/binary-search.py
@@ -1039,8 +1039,8 @@ def handle_trial_process_stderr(process, trial_params, stats, tmp_stats, streams
                                  stats[device_pair['tx']]['tx_l2_bps'] = float(stats[device_pair['tx']]['tx_l2_bps']) / float(results['global']['runtime']) * tmp_stats[device_pair['tx']]['bits_per_byte']
                                  stats[device_pair['rx']]['rx_l2_bps'] = float(stats[device_pair['rx']]['rx_l2_bps']) / float(results['global']['runtime']) * tmp_stats[device_pair['tx']]['bits_per_byte']
 
-                                 print("Device Pair: %s |   All TX   | packets=%s rate=%s l1_bps=%s l2_bps=%s" % (device_pair['path'], commify(stats[device_pair['tx']]['tx_packets']), commify(stats[device_pair['tx']]['tx_pps']), commify(stats[device_pair['tx']]['tx_l1_bps'], stats[device_pair['tx']]['tx_l2_bps'])))
-                                 print("Device Pair: %s |   All RX   | packets=%s rate=%s l1_bps=%s l2_bps=%s" % (device_pair['path'], commify(stats[device_pair['rx']]['rx_packets']), commify(stats[device_pair['rx']]['rx_pps']), commify(stats[device_pair['rx']]['rx_l1_bps'], stats[device_pair['rx']]['rx_l2_bps'])))
+                                 print("Device Pair: %s |   All TX   | packets=%s rate=%s l1_bps=%s l2_bps=%s" % (device_pair['path'], commify(stats[device_pair['tx']]['tx_packets']), commify(stats[device_pair['tx']]['tx_pps']), commify(stats[device_pair['tx']]['tx_l1_bps']), commify(stats[device_pair['tx']]['tx_l2_bps'])))
+                                 print("Device Pair: %s |   All RX   | packets=%s rate=%s l1_bps=%s l2_bps=%s" % (device_pair['path'], commify(stats[device_pair['rx']]['rx_packets']), commify(stats[device_pair['rx']]['rx_pps']), commify(stats[device_pair['rx']]['rx_l1_bps']), commify(stats[device_pair['rx']]['rx_l2_bps'])))
 
                                  if trial_params['measure_latency']:
                                       stream_types.append('latency')


### PR DESCRIPTION
001:TRex Events:
001:    EVENT: 2018-08-16 06:08:13 - [server][info]     - Port 0 has started
001:    EVENT: 2018-08-16 06:08:13 - [server][info]     - Port 1 has started
001:    EVENT: 2018-08-16 06:09:13 - [server][info]     - Port 0 job done
001:    EVENT: 2018-08-16 06:09:13 - [server][info]     - Port 1 job done
001:TX Utilization: 7.898000%
001:RX Utilization: 0.000629%
001:TX Queue Full:  0
001:Disconnecting from TRex server...
001:Connection severed
We hit this kind of error, fix this typo error.

Exception in thread Thread-4:
Traceback (most recent call last):
  File "/usr/lib64/python2.7/threading.py", line 812, in __bootstrap_inner
    self.run()
  File "/usr/lib64/python2.7/threading.py", line 765, in run
    self.__target(*self.__args, **self.__kwargs)
  File "./binary-search.py", line 1042, in handle_trial_process_stderr
    print("Device Pair: %s |   All TX   | packets=%s rate=%s l1_bps=%s l2_bps=%s" % (device_pair['path'], commify(stats[device_pair['tx']]['tx_packets']), commify(stats[device_pair['tx']]['tx_pps']), commify(stats[device_pair['tx']]['tx_l1_bps'], stats[device_pair['tx']]['tx_l2_bps'])))
TypeError: commify() takes exactly 1 argument (2 given)
