### PR TITLE
trex_tg_lib.py: ensure trex profile property exists

### DIFF
--- a/trex_tg_lib.py
+++ b/trex_tg_lib.py
@@ -535,7 +535,7 @@ def trex_profiler_process_sample(sample, stats):
                 for port in sorted(data['rx_pps']):
                     stat_sample['rx_pps'][port] = data['tx_pps'][port]
 
-                if pgid in sample['pgid']['latency']:
+                if 'latency' in sample['pgid'] and pgid in sample['pgid']['latency']:
                     data = sample['pgid']['latency'][pgid]['latency']
                     stat_sample['latency'] = { 'average': data['average'],
                                                'total_max': data['total_max'],


### PR DESCRIPTION
- Make sure a trex profiler sample includes a ['pgid']['latency']
  property before accessing it.

- It appears that a timing issue could cause this field to not exist
  yet when a sample is collected (this is somewhat speculative).