### PR TITLE
trex_tg_lib.py: catch a corner case error in create_generic_pkt

### DIFF
--- a/trex_tg_lib.py
+++ b/trex_tg_lib.py
@@ -201,6 +201,8 @@ def create_generic_pkt (size, mac_src, mac_dst, ip_src, ip_dst, port_src, port_d
               num_flows_divisor = 1000
          elif (num_flows % 1024 == 0):
               num_flows_divisor = 1024
+         else:
+             raise ValueError("When source and/or destination port flows are enabled then the per stream flow count must be less than 1000, divisible by 1000, or divisible by 1024 (not %d)." % (num_flows))
 
          if (port_src + num_flows_divisor) > port_range["end"]:
               port_start = port_range["end"] - num_flows_divisor + 1


### PR DESCRIPTION
- When trex-txrx is being used there is code further up the stack that
  avoids this error, but in trex-txrx-profile the execution can reach
  this point without having validated the value so provide a mechanism
  for handling the error case.

- It probably is wise to always have a proper default "else" clause
  regardless of what the expectation of upstream validations is.