### PR TITLE
binary-search.py: correct divide by zero bug

### DIFF
--- a/binary-search.py
+++ b/binary-search.py
@@ -1391,7 +1391,10 @@ def handle_trial_process_stderr(process, trial_params, stats, tmp_stats, streams
                                  stats[device_pair['rx']]['rx_active'] = True
 
                                  stats[device_pair['rx']]['rx_latency_lost_packets'] = stats[device_pair['tx']]['tx_latency_packets'] - stats[device_pair['rx']]['rx_latency_packets']
-                                 stats[device_pair['rx']]['rx_latency_lost_packets_pct'] = 100.0 * stats[device_pair['rx']]['rx_latency_lost_packets'] / stats[device_pair['tx']]['tx_latency_packets']
+                                 if stats[device_pair['tx']]['tx_latency_packets']:
+                                      stats[device_pair['rx']]['rx_latency_lost_packets_pct'] = 100.0 * stats[device_pair['rx']]['rx_latency_lost_packets'] / stats[device_pair['tx']]['tx_latency_packets']
+                                 else:
+                                      stats[device_pair['rx']]['rx_latency_lost_packets_pct'] = 0.0
 
                                  stats[device_pair['tx']]['tx_latency_pps'] = float(stats[device_pair['tx']]['tx_latency_packets']) / float(results['global']['runtime'])
                                  stats[device_pair['rx']]['rx_latency_pps'] = float(stats[device_pair['rx']]['rx_latency_packets']) / float(results['global']['runtime'])


### PR DESCRIPTION
- Check for the presence of TX latency packets (ie. > 0) before using
  it as the divisor.  In trex-txrx-profile.py it is possible for
  streams to have latency packets disabled in the profile definition
  even though latency analysis is enabled at the global level.  If a
  stream has latency packets disabled while latency analysis is
  enabled globally then during analysis of the trial results a divide
  by zero error would occour.