### PR TITLE
trex-txrx-profile.py: allow streams to be enabled/disabled in the pro…

### DIFF
--- a/README-trex-txrx-profile.md
+++ b/README-trex-txrx-profile.md
@@ -40,3 +40,5 @@ by the following parameters:
 16. repeat_flows - optional, if the stream repeats should it use the same flows, defaults to True, options are [True, False]
 
 17. the_packet - optional, a packet definition to use as the base packet for this stream, ie. "scapy:Ether()/IP()/TCP()/'payload'", when this option is used it overrides 'frame_type', 'protocol', and 'stream_id'.
+
+18. enabled - optional, determines whether the defined stream is actually used to define traffic, can be used to easily turn a stream on or off while testing, defaults to True, options are [True, False]

--- a/trex-txrx-profile.py
+++ b/trex-txrx-profile.py
@@ -592,6 +592,11 @@ def build_warmup_segments(segments, rate, flows):
      return(warmup_segments)
 
 def create_stream (stream, device_pair, direction, other_direction, flow_scaler):
+    if not stream['enabled']:
+         myprint("")
+         myprint("\tSkipping stream %d for '%s' due to explicit disablement in the profile" % (stream['profile_id'], device_pair[direction]['id_string']))
+         return
+
     if stream['offset'] >= t_global.args.runtime:
          myprint("")
          myprint("\tSkipping stream %d for '%s' due to offset >= runtime" % (stream['profile_id'], device_pair[direction]['id_string']))

--- a/trex_tg_lib.py
+++ b/trex_tg_lib.py
@@ -486,13 +486,15 @@ def create_profile_stream (flows = 0,
                            latency_only = False,
                            protocol = 'UDP',
                            traffic_direction = 'bidirectional',
-                           stream_id = None ):
+                           stream_id = None,
+                           enabled = True ):
     stream = { 'flows': flows,
                'frame_size': frame_size,
                'flow_mods': copy.deepcopy(flow_mods),
                'rate': rate,
                'frame_type': frame_type,
                'stream_types': [],
+               'enabled': enabled,
                'latency': latency,
                'latency_only': latency_only,
                'protocol': protocol,
@@ -516,7 +518,7 @@ def create_profile_stream (flows = 0,
 
 def validate_profile_stream(stream, rate_modifier):
     for key in stream:
-        if not key in [ 'flows', 'frame_size', 'flow_mods', 'rate', 'frame_type', 'stream_types', 'latency', 'latency_only', 'protocol', 'traffic_direction', 'stream_id', 'offset', 'duration', 'repeat', 'repeat_delay', 'repeat_flows', 'the_packet' ]:
+        if not key in [ 'flows', 'frame_size', 'flow_mods', 'rate', 'frame_type', 'stream_types', 'latency', 'latency_only', 'protocol', 'traffic_direction', 'stream_id', 'offset', 'duration', 'repeat', 'repeat_delay', 'repeat_flows', 'the_packet', 'enabled' ]:
             raise ValueError("Invalid property found (%s)" % (key))
 
         if isinstance(stream[key], basestring):
@@ -555,6 +557,9 @@ def validate_profile_stream(stream, rate_modifier):
 
     if not 'latency' in stream:
         stream['latency'] = True
+
+    if not 'enabled' in stream:
+        stream['enabled'] = True
 
     if not 'protocol' in stream:
         stream['protocol'] = 'UDP'


### PR DESCRIPTION
…file

- Adds a new Boolean parameter, "enabled", to a stream's profile
  definition.  This is useful for easily turning on or off a stream
  from a profile when doing various debugging and analysis runs
  without having to actually remove the stream from the profile.