### PR TITLE
Add xena-txrx.py helper module stub, link to the module from binary-s…

### DIFF
--- a/binary-search.py
+++ b/binary-search.py
@@ -835,7 +835,7 @@ def run_trial (trial_params, port_info, stream_info, detailed_stats):
         cmd = cmd + flow_mods_opt
     elif trial_params['traffic_generator'] == 'xena':
          # TODO: pass binary search trial parameters to external helper module (xena-txrx.py)
-         print('Xena traffic generator - run_trial() placeholder stub')
+         cmd = 'python -u ' + t_global.trafficgen_dir + 'xena-txrx.py'
          sys.exit()
     elif trial_params['traffic_generator'] == 'null-txrx':
          cmd = 'python -u ' + t_global.trafficgen_dir + '/null-txrx.py'

--- a/xena-txrx.py
+++ b/xena-txrx.py
@@ -1,0 +1,18 @@
+#!/bin/python -u
+from __future__ import print_function
+
+# xena-txrx is currently a stub
+# script will interface between binary-search.py and XenaPythonLib
+
+# TODO: imports
+
+# TODO: create argument parser
+
+# TODO: include XenaPythonLib functionality
+
+def main():
+    print('Called xena-txrx.py helper module stub')
+
+if __name__ == '__main__':
+    main()
+


### PR DESCRIPTION
…earch.py

xena-txrx.py will interface between binary-search.py and the XenaPythonLib. For now the new script is only an empty stub.

(@ctrautma for reference)