### PR TITLE
add function - connect/disconnect from chassis 

### DIFF
--- a/xena-txrx.py
+++ b/xena-txrx.py
@@ -3,10 +3,13 @@ from __future__ import print_function
 
 import argparse
 import sys
+import time
+from xenalib.XenaSocket import XenaSocket
+from xenalib.XenaManager import XenaManager
 # TODO: imports
 
-# xena-txrx is currently a stub
-# script will interface between binary-search.py and XenaPythonLib
+# overview: xena-txrx is currently in development
+# script interfaces between binary-search.py and XenaPythonLib
 
 # argument parser
 class t_global(object):
@@ -66,15 +69,37 @@ def args_print(*args, **kwargs):
           del kwargs['stderr_only']
      if not stderr_only:
           print(*args, **kwargs)
-     if stderr_only or t_global.args.mirrored_log:
+     if stderr_only:
           print(*args, file = sys.stderr, **kwargs)
      return
 
-# TODO: include XenaPythonLib functionality
+# TODO: expand XenaPythonLib functionality
 
 def main():
     process_options()
-    print('Called xena-txrx.py helper module stub')
+
+    xenaUsr = t_global.args.xena_user
+    xenaPwd = t_global.args.xena_pwd
+    xenaChassis = t_global.args.xena_chassis
+    # possible TODO: verify chassis ip input format?
+
+    # create the communication socket
+    xsocket = XenaSocket(xenaChassis)
+
+    # connect to Xena chassis
+    try:
+        xsocket.connect()
+        print('Xena chassis connection successful')
+        
+    except TypeError:
+        # failure to connect returns object 'timeout', throws TypeError
+        print('Error: connection to Xena chassis failed')
+
+    else:
+        time.sleep(5) # gives enough time to show up in ValkyrieManager
+        print('Disconnecting from Xena chassis...')
+        del xsocket
+    
     sys.exit()
 
 if __name__ == '__main__':

--- a/xena-txrx.py
+++ b/xena-txrx.py
@@ -1,17 +1,81 @@
 #!/bin/python -u
 from __future__ import print_function
 
+import argparse
+import sys
+# TODO: imports
+
 # xena-txrx is currently a stub
 # script will interface between binary-search.py and XenaPythonLib
 
-# TODO: imports
+# argument parser
+class t_global(object):
+    args=None
 
-# TODO: create argument parser
+def process_options():
+    parser = argparse.ArgumentParser(usage=""" 
+    generate network traffic and report packet loss
+    """)
+
+    parser.add_argument('--active-device-pairs',
+                        dest='active_device_pairs',
+                        help='List of active device pairs in the form A:B[,C:D][,E:F][,...]',
+                        default='--',
+                        )
+    parser.add_argument('--device-pairs',
+                        dest='device_pairs',
+                        help='List of device pairs in the form A:B[,C:D][,E:F][,...]',
+                        default="0:1",
+                        )
+    parser.add_argument('--rate', 
+                        dest='rate',
+                        help='rate per device',
+                        default = 0.0,
+                        type = float
+                        )
+    parser.add_argument('--runtime', 
+                        dest='runtime',
+                        help='trial period in seconds',
+                        default=30,
+                        type = int,
+                        )
+    parser.add_argument("--xena_chassis",
+                        dest='xena_chassis',
+                        help='Argument for use with Xena; specifies the IP address of the Xena chassis to connect to',
+                        type=str
+                        )
+    parser.add_argument("--xena_pwd",
+                        dest='xena_pwd',
+                        help='Optional argument for Xena session; defaults to "xena"',
+                        default='xena',
+                        type=str
+                        )
+    parser.add_argument("--xena_user",
+                        dest='xena_user',
+                        help='The user for a Xena chassis session. String is limited to 8 characters',
+                        type=str
+                        )
+
+    t_global.args = parser.parse_args()
+    args_print(t_global.args)
+
+def args_print(*args, **kwargs):
+     stderr_only = False
+     if 'stderr_only' in kwargs:
+          stderr_only = kwargs['stderr_only']
+          del kwargs['stderr_only']
+     if not stderr_only:
+          print(*args, **kwargs)
+     if stderr_only or t_global.args.mirrored_log:
+          print(*args, file = sys.stderr, **kwargs)
+     return
 
 # TODO: include XenaPythonLib functionality
 
 def main():
+    process_options()
     print('Called xena-txrx.py helper module stub')
+    sys.exit()
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Incorporates basic XenaPythonLib functionality by connecting to a Xena chassis. Failed connection attempts trigger an exception and print an error message. Successful connection prints a status message, waits five seconds, then disconnects from the server.

Note: xena-txrx.py exits gracefully if called directly from cli (ex: python -u xena-txrx.py --xena_chassis=11.11.11.11 --xena_user=userX). If called from binary-search.py (ex: python3 binary-search.py --traffic-generator=xena --xena_user=userX --xena_chassis=11.11.11.11) the parent script crashes in def evaluate_trial() (after running xena-txrx). This behavior is expected because of xena-txrx's currently limited functionality, and will be addressed in the next patch.

(@ctrautma for reference)
