### PR TITLE
add chassis connect/disconnect

### DIFF
--- a/xena-txrx.py
+++ b/xena-txrx.py
@@ -3,7 +3,6 @@ from __future__ import print_function
 
 import argparse
 import sys
-import time
 from xenalib.XenaSocket import XenaSocket
 from xenalib.XenaManager import XenaManager
 
@@ -79,7 +78,7 @@ def main():
     
     xenaUsr = t_global.args.xena_user
     xenaPwd = t_global.args.xena_chassis
-    xenaChassis = t_global.args.xena_chasis
+    xenaChassis = t_global.args.xena_chassis
 
     # create the communication socket
     xsocket = XenaSocket(xenaChassis)
@@ -88,12 +87,11 @@ def main():
     try:
         xsocket.connect()
         print('Xena chassis connection successful')
-    except TypeError:
+    except Exception as e:
         # failure to connect returns object 'timeout', triggering a TypeError
-        print('Error: connection to Xena chassis failed.')
+        print('Error: connection to Xena chassis failed;', e)
     else:
         # executes if no exception
-        time.sleep(5) # pause so connection appears in Valkyrie Manager
         print('Disconnecting from Xena chassis...')
         del xsocket
 

--- a/xena-txrx.py
+++ b/xena-txrx.py
@@ -3,10 +3,12 @@ from __future__ import print_function
 
 import argparse
 import sys
-# TODO: imports
+import time
+from xenalib.XenaSocket import XenaSocket
+from xenalib.XenaManager import XenaManager
 
-# xena-txrx is currently a stub
-# script will interface between binary-search.py and XenaPythonLib
+# overview: xena-txrx is currently in development
+# script interfaces between binary-search.py and XenaPythonLib
 
 # argument parser
 class t_global(object):
@@ -66,15 +68,35 @@ def args_print(*args, **kwargs):
           del kwargs['stderr_only']
      if not stderr_only:
           print(*args, **kwargs)
-     if stderr_only or t_global.args.mirrored_log:
+     if stderr_only:
           print(*args, file = sys.stderr, **kwargs)
      return
 
-# TODO: include XenaPythonLib functionality
+# TODO: expand XenaPythonLib functionality
 
 def main():
     process_options()
-    print('Called xena-txrx.py helper module stub')
+    
+    xenaUsr = t_global.args.xena_user
+    xenaPwd = t_global.args.xena_chassis
+    xenaChassis = t_global.args.xena_chasis
+
+    # create the communication socket
+    xsocket = XenaSocket(xenaChassis)
+
+    # connect to Xena chassis, raise exception if fail
+    try:
+        xsocket.connect()
+        print('Xena chassis connection successful')
+    except TypeError:
+        # failure to connect returns object 'timeout', triggering a TypeError
+        print('Error: connection to Xena chassis failed.')
+    else:
+        # executes if no exception
+        time.sleep(5) # pause so connection appears in Valkyrie Manager
+        print('Disconnecting from Xena chassis...')
+        del xsocket
+
     sys.exit()
 
 if __name__ == '__main__':


### PR DESCRIPTION
Incorporates basic XenaPythonLib functionality by connecting to a Xena chassis. Failed connection attempts trigger an exception and print an error message. Successful connection prints a status message, waits five seconds, then disconnects from the server.

Note: xena-txrx.py exits gracefully if called directly from cli (ex: python -u xena-txrx.py --xena_chassis=11.11.11.11 --xena_user=userX). If called from binary-search.py (ex: python3 binary-search.py --traffic-generator=xena --xena_user=userX --xena_chassis=11.11.11.11) the parent script crashes in def evaluate_trial() (after running xena-txrx). This behavior is expected because of xena-txrx's currently limited functionality, and will be addressed in the next patch.

(@ctrautma for reference)

*this pull request corrects procedural missteps originally made in #142, #143