### PR TITLE
add minimal support for remote TRex hosts

### DIFF
--- a/binary-search.py
+++ b/binary-search.py
@@ -473,6 +473,12 @@ def process_options ():
                         help = 'Do not allow binary search to increase beyond the initial rate if it passes final validation',
                         action = 'store_true',
                         )
+    parser.add_argument('--trex-host',
+                        dest = 'trex_host',
+                        help = 'Hostname/IP address of the server where TRex is running',
+                        default = 'localhost',
+                        type = str
+                        )
     parser.add_argument("--xena_user",
                         dest='xena_user',
                         help='The user for a Xena chassis session. String is limited to 8 characters',
@@ -854,6 +860,7 @@ def run_trial (trial_params, port_info, stream_info, detailed_stats):
              tmp_stats[tmp_stats_id]['tx_available_bandwidth'] = port_info[tmp_stats_id]['speed'] * 1000 * 1000 * 1000
 
         cmd = 'python -u ' + t_global.trafficgen_dir + '/trex-txrx-profile.py'
+        cmd = cmd + ' --trex-host=' + str(trial_params['trex_host'])
         cmd = cmd + ' --mirrored-log'
         cmd = cmd + ' --random-seed=' + str(trial_params['random_seed'])
         cmd = cmd + ' --device-pairs=' + str(trial_params['device_pairs'])
@@ -888,6 +895,7 @@ def run_trial (trial_params, port_info, stream_info, detailed_stats):
              tmp_stats[tmp_stats_id]['tx_available_bandwidth'] = port_info[tmp_stats_id]['speed'] * 1000 * 1000 * 1000
 
         cmd = 'python -u ' + t_global.trafficgen_dir + '/trex-txrx.py'
+        cmd = cmd + ' --trex-host=' + str(trial_params['trex_host'])
         cmd = cmd + ' --device-pairs=' + str(trial_params['device_pairs'])
         cmd = cmd + ' --active-device-pairs=' + str(trial_params['active_device_pairs'])
         cmd = cmd + ' --mirrored-log'
@@ -1978,6 +1986,7 @@ def main():
          setup_config_var("vlan_ids", t_global.args.vlan_ids, trial_params)
 
     if t_global.args.traffic_generator == "trex-txrx" or t_global.args.traffic_generator == "trex-txrx-profile":
+         setup_config_var("trex_host", t_global.args.trex_host, trial_params)
          setup_config_var("device_pairs", t_global.args.device_pairs, trial_params)
          setup_config_var('active_device_pairs', t_global.args.active_device_pairs, trial_params)
          setup_config_var("rate_unit", t_global.args.rate_unit, trial_params)

--- a/trex-txrx-profile.py
+++ b/trex-txrx-profile.py
@@ -71,6 +71,12 @@ def setup_global_variables ():
 def process_options ():
     parser = argparse.ArgumentParser(usage="generate network traffic and report packet loss")
 
+    parser.add_argument('--trex-host',
+                        dest='trex_host',
+                        help='Hostname/IP address of the server where TRex is running',
+                        default='localhost',
+                        type = str
+                        )
     parser.add_argument('--debug',
                         dest='debug',
                         help='Should debugging be enabled',
@@ -1265,7 +1271,7 @@ def main():
     myprint(dump_json_readable(traffic_profile), stderr_only = True)
     myprint("PARSABLE TRAFFIC PROFILE: %s" % dump_json_parsable(traffic_profile), stderr_only = True)
 
-    c = STLClient()
+    c = STLClient(server = t_global.args.trex_host)
 
     try:
         thread_exit = threading.Event()

--- a/trex-txrx.py
+++ b/trex-txrx.py
@@ -381,6 +381,12 @@ def process_options ():
     generate network traffic and report packet loss
     """);
 
+    parser.add_argument('--trex-host',
+                        dest='trex_host',
+                        help='Hostname/IP address of the server where TRex is running',
+                        default='localhost',
+                        type = str
+                        )
     parser.add_argument('--debug',
                         dest='debug',
                         help='Should debugging be enabled',
@@ -829,7 +835,7 @@ def main():
                                'max_latency_pg_ids': 0,
                                'device_pair': device_pair })
 
-    c = STLClient()
+    c = STLClient(server = t_global.args.trex_host)
     passed = True
 
     stats = 0


### PR DESCRIPTION
- This adds runtime support to the scripts involved in running the
  test (binary-search.py, trex-txrx.py, and trex-txrx-profile.py).

- This is no way addresses installing, configuring, and/or launching
  TRex on the remote host.