### PR TITLE
ensure minimum latency data exists before processing it

### DIFF
--- a/binary-search.py
+++ b/binary-search.py
@@ -1260,8 +1260,9 @@ def handle_trial_process_stderr(process, trial_params, stats, tmp_stats, streams
                                                      if float(results["latency"][str(pg_id)]["latency"]["total_max"]) > stats[device_pair['rx']]['rx_latency_maximum']:
                                                           stats[device_pair['rx']]['rx_latency_maximum'] = float(results["latency"][str(pg_id)]["latency"]["total_max"])
 
-                                                     if stats[device_pair['rx']]['rx_latency_minimum'] == 0.0 or float(results["latency"][str(pg_id)]["latency"]["total_min"]) < stats[device_pair['rx']]['rx_latency_minimum']:
-                                                          stats[device_pair['rx']]['rx_latency_minimum'] = float(results["latency"][str(pg_id)]["latency"]["total_min"])
+                                                     if results["latency"][str(pg_id)]["latency"]["total_min"] != "N/A":
+                                                          if stats[device_pair['rx']]['rx_latency_minimum'] == 0.0 or float(results["latency"][str(pg_id)]["latency"]["total_min"]) < stats[device_pair['rx']]['rx_latency_minimum']:
+                                                               stats[device_pair['rx']]['rx_latency_minimum'] = float(results["latency"][str(pg_id)]["latency"]["total_min"])
                                            else:
                                                 stats_error_append_pg_id(stats[device_pair['rx']], 'rx_missing', pg_id)
 
@@ -1416,8 +1417,9 @@ def handle_trial_process_stderr(process, trial_params, stats, tmp_stats, streams
                                                      if float(results["latency"][str(pg_id)]["latency"]["total_max"]) > stats[device_pair['rx']]['rx_latency_maximum']:
                                                           stats[device_pair['rx']]['rx_latency_maximum'] = float(results["latency"][str(pg_id)]["latency"]["total_max"])
 
-                                                     if stats[device_pair['rx']]['rx_latency_minimum'] == 0.0 or float(results["latency"][str(pg_id)]["latency"]["total_min"]) < stats[device_pair['rx']]['rx_latency_minimum']:
-                                                          stats[device_pair['rx']]['rx_latency_minimum'] = float(results["latency"][str(pg_id)]["latency"]["total_min"])
+                                                     if results["latency"][str(pg_id)]["latency"]["total_min"] != "N/A":
+                                                          if stats[device_pair['rx']]['rx_latency_minimum'] == 0.0 or float(results["latency"][str(pg_id)]["latency"]["total_min"]) < stats[device_pair['rx']]['rx_latency_minimum']:
+                                                               stats[device_pair['rx']]['rx_latency_minimum'] = float(results["latency"][str(pg_id)]["latency"]["total_min"])
                                            else:
                                                 stats_error_append_pg_id(stats[device_pair['rx']], 'rx_missing', pg_id)
 


### PR DESCRIPTION
- When trex-txrx.py is used with the segment monitor enabled it is
  possible for a trial to exit before a stream is run.  When this
  happens there is no latency data available and the "total_min" is
  set to "N/A" which cannot be converted to a float in Python and
  results in an exception.  Check for this condition before processing
  the value -- we can ignore the case where it occurs because that
  trial exit state is handled elsewhere.