### PR TITLE
profile-builder.py: change rate from pps to mpps

### DIFF
--- a/profile-builder.py
+++ b/profile-builder.py
@@ -60,8 +60,8 @@ def process_options ():
                         )
     parser.add_argument('--rate', 
                         dest='rate',
-                        help='Packet rate per device per stream',
-                        default = 1000000.0,
+                        help='Packet rate per device per stream (mpps)',
+                        default = 1.0,
                         type = float
                         )
     parser.add_argument('--measure-latency',
@@ -153,7 +153,7 @@ def main ():
     stream = create_profile_stream(flows = t_global.args.num_flows,
                                    frame_size = t_global.args.frame_size,
                                    flow_mods = flow_mods,
-                                   rate = t_global.args.rate,
+                                   rate = t_global.args.rate * 1000000.0,
                                    frame_type = 'generic',
                                    measurement = True,
                                    teaching_warmup = integrated_teaching_warmup,


### PR DESCRIPTION
- Setting rate to mpps makes the behavior consistent with
  binary-search.py and trex-txrx.py.

- This change makes it possible to change from trex-txrx.py to
  trex-txrx-profile.py with as little as no other changes.