### PR TITLE
trex-txrx.py: bugfix for sub stream names

### DIFF
--- a/trex-txrx.py
+++ b/trex-txrx.py
@@ -342,7 +342,10 @@ def create_traffic_profile (direction, device_pair, rate_multiplier, port_speed)
 
                     substream_self_start = stream_self_start
                     for loop_idx in range(1, stream_loops+1):
-                         substream_name = "%s_sub_%d" % (stream_name, loop_idx)
+                         if loop_idx == 1:
+                              substream_name = stream_name
+                         else:
+                              substream_name = "%s_sub_%d" % (stream_name, loop_idx)
                          substream_next_name = "%s_sub_%d" % (stream_name, loop_idx+1)
                          myprint("Creating substream %d with name %s" % (loop_idx, substream_name))
 


### PR DESCRIPTION
- When a stream has to be broken down into substreams, other streams
  are unaware that this happens.  When streams where chained together,
  a stream (say the first stream -- or at least the last substream of
  the first stream) would be pointing at the incorrect stream name for
  the next stream in the chain (the second stream) if it had been
  broken into substreams.

- This patch changes substream names so that the first substream
  maintains the same name as the non-broken down stream.  This leads
  to a slightly odd naming scenario:

  1. default_stream_0->1_UDP_segment_1
  2. default_stream_0->1_UDP_segment_1_sub_2
  3. default_stream_0->1_UDP_segment_2
  4. default_stream_0->1_UDP_segment_2_sub_2
  5. default_stream_0->1_UDP_segment_3
  6. default_stream_0->1_UDP_segment_3_sub_2

  as opposed to the old (and broken) way:

  1. default_stream_0->1_UDP_segment_1_sub_1
  2. default_stream_0->1_UDP_segment_1_sub_2 was pointing to default_stream_0->1_UDP_segment_2 instead of default_stream_0->1_UDP_segment_2_sub_1
  3. default_stream_0->1_UDP_segment_2_sub_1
  4. default_stream_0->1_UDP_segment_2_sub_2 was pointing to default_stream_0->1_UDP_segment_3 instead of default_stream_0->1_UDP_segment_3_sub_1
  5. default_stream_0->1_UDP_segment_3_sub_1
  6. default_stream_0->1_UDP_segment_3_sub_2

- The alternative approach would have been to teach streams what other
  streams were doing, but that would be significantly more
  complicated.