### PR TITLE
Add support for virtual-functions (VFs)

### DIFF
--- a/binary-search.py
+++ b/binary-search.py
@@ -479,6 +479,11 @@ def process_options ():
                         default = 'localhost',
                         type = str
                         )
+    parser.add_argument('--no-promisc',
+                        dest='no_promisc',
+                        help='Do not use promiscuous mode for interfaces (usually needed for virtual functions)',
+                        action = 'store_true',
+                        )
 
     t_global.args = parser.parse_args();
     if t_global.args.frame_size == "IMIX":
@@ -810,6 +815,10 @@ def run_trial (trial_params, port_info, stream_info, detailed_stats):
              cmd = cmd + ' --traffic-profile=' + trial_params['warmup_traffic_profile']
         else:
              cmd = cmd + ' --traffic-profile=' + trial_params['traffic_profile']
+        if trial_params['no_promisc']:
+             cmd = cmd + ' --no-promisc'
+        else:
+             print("--no-promisc is not set")
 
     elif trial_params['traffic_generator'] == 'trex-txrx':
         for tmp_stats_index, tmp_stats_id in enumerate(tmp_stats):
@@ -883,6 +892,10 @@ def run_trial (trial_params, port_info, stream_info, detailed_stats):
              cmd = cmd + ' --teaching-warmup-packet-type=' + str(trial_params['teaching_warmup_packet_type'])
         if trial_params['teaching_measurement_packet_type']:
              cmd = cmd + ' --teaching-measurement-packet-type=' + str(trial_params['teaching_measurement_packet_type'])
+        if trial_params['no_promisc']:
+             cmd = cmd + ' --no-promisc'
+        else:
+             print("--no-promisc is not set")
 
     previous_sig_handler = signal.signal(signal.SIGINT, sigint_handler)
 
@@ -1888,6 +1901,7 @@ def main():
          setup_config_var('teaching_measurement_interval', t_global.args.teaching_measurement_interval, trial_params)
          setup_config_var('teaching_warmup_packet_rate', t_global.args.teaching_warmup_packet_rate, trial_params)
          setup_config_var('teaching_measurement_packet_rate', t_global.args.teaching_measurement_packet_rate, trial_params)
+         setup_config_var('no_promisc', t_global.args.no_promisc, trial_params)
 
     if t_global.args.traffic_generator == "null-txrx":
          # empty for now

--- a/binary-search.py
+++ b/binary-search.py
@@ -817,8 +817,6 @@ def run_trial (trial_params, port_info, stream_info, detailed_stats):
              cmd = cmd + ' --traffic-profile=' + trial_params['traffic_profile']
         if trial_params['no_promisc']:
              cmd = cmd + ' --no-promisc'
-        else:
-             print("--no-promisc is not set")
 
     elif trial_params['traffic_generator'] == 'trex-txrx':
         for tmp_stats_index, tmp_stats_id in enumerate(tmp_stats):
@@ -894,8 +892,6 @@ def run_trial (trial_params, port_info, stream_info, detailed_stats):
              cmd = cmd + ' --teaching-measurement-packet-type=' + str(trial_params['teaching_measurement_packet_type'])
         if trial_params['no_promisc']:
              cmd = cmd + ' --no-promisc'
-        else:
-             print("--no-promisc is not set")
 
     previous_sig_handler = signal.signal(signal.SIGINT, sigint_handler)
 

--- a/trex-txrx-profile.py
+++ b/trex-txrx-profile.py
@@ -184,6 +184,11 @@ def process_options ():
                         default = 'trex-profiler.log',
                         type = str
                         )
+    parser.add_argument('--no-promisc',
+                        dest='no_promisc',
+                        help='Do not use promiscuous mode for network interfaces (usually needed for virtual-functions)',
+                        action = 'store_true',
+                        )
 
     t_global.args = parser.parse_args()
 
@@ -1289,8 +1294,10 @@ def main():
         # prepare our ports
         c.acquire(ports = claimed_device_pairs, force=True)
         c.reset(ports = claimed_device_pairs)
-        c.set_port_attr(ports = all_ports, promiscuous = True)
-
+        if t_global.args.no_promisc:
+             c.set_port_attr(ports = all_ports)
+        else:
+             c.set_port_attr(ports = all_ports, promiscuous = True)
         port_info = c.get_port_info(ports = claimed_device_pairs)
         myprint("READABLE PORT INFO:", stderr_only = True)
         myprint(dump_json_readable(port_info), stderr_only = True)
@@ -1438,7 +1445,10 @@ def main():
                        return return_value
 
                   c.reset(ports = warmup_ports)
-                  c.set_port_attr(ports = warmup_ports, promiscuous = True)
+                  if t_global.args.no_promisc:
+                       c.set_port_attr(ports = warmup_ports)
+                  else:
+                       c.set_port_attr(ports = warmup_ports, promiscuous = True)
              else:
                   myprint("\tNo streams configured")
 

--- a/trex-txrx.py
+++ b/trex-txrx.py
@@ -651,6 +651,11 @@ def process_options ():
                         default = 'garp',
                         choices = ['garp', 'icmp', 'generic']
                         )
+    parser.add_argument('--no-promisc',
+                        dest='no_promisc',
+                        help='Do not use promiscuous mode for network interfaces (usually needed for virtual-functions)',
+                        action = 'store_true',
+                        )
 
     t_global.args = parser.parse_args();
     if t_global.args.frame_size == "IMIX":
@@ -880,8 +885,10 @@ def main():
         # prepare our ports
         c.acquire(ports = claimed_device_pairs, force=True)
         c.reset(ports = claimed_device_pairs)
-        c.set_port_attr(ports = all_ports, promiscuous = True)
-
+        if t_global.args.no_promisc:
+             c.set_port_attr(ports = all_ports)
+        else:
+             c.set_port_attr(ports = all_ports, promiscuous = True)
         port_info = c.get_port_info(ports = claimed_device_pairs)
         myprint("READABLE PORT INFO:", stderr_only = True)
         myprint(dump_json_readable(port_info), stderr_only = True)
@@ -1128,7 +1135,10 @@ def main():
                   return return_value
 
              c.reset(ports = warmup_ports)
-             c.set_port_attr(ports = warmup_ports, promiscuous = True)
+             if t_global.args.no_promisc:
+                  c.set_port_attr(ports = warmup_ports)
+             else:
+                  c.set_port_attr(ports = warmup_ports, promiscuous = True)
 
         run_ports = []
 


### PR DESCRIPTION
- The TRex scripts here are originally designed for physical-functions (PFs)
- This adds the necessary function to work with VFs, if those VFs are
  supported by TRex.  To date, we know VFs frpm Intel X710-based NICs
  work with TRex.
- Add option to allow no promisc mode for Trex interfaces
- Allow the user to specify the CPUs used when launching TRex.  This
  may be of use when you do not want to assume all nohz_full CPUs
  are to be used for TRex.