### PR TITLE
TRex install role

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,31 @@
+# TRex install role
+The ansible install-trex role downloads, unarchives, and installs trex on your
+trafficgen host.
+
+## Configfure Ansible inventory file
+Add `trafficgen` host to /etc/ansible/hosts
+```
+sudo echo "trafficgen" >> /etc/ansible/hosts
+```
+
+## Add trafficgen to /etc/hosts
+Replace `127.0.0.1` with the actual trafficgen address
+```
+echo "127.0.0.1 trafficgen" >> /etc/hosts
+```
+
+## Make sure you can ssh to trafficgen host
+```
+ssh trafficgen
+```
+
+## Install Trex with ansible role
+To install TRex using ansible, run:
+```
+ansible-playbook install-trex.yaml
+```
+
+### Specifying custom options
+```
+ansible-playbook install-trex.yaml -e trex_ver=v2.82 -e force_install=True -e enable_ssl=False
+```

--- a/install-trex.yaml
+++ b/install-trex.yaml
@@ -1,0 +1,6 @@
+---
+- hosts: trafficgen
+  tasks:
+    - name: Install trex
+      include_role:
+        name: install-trex

--- a/roles/install-trex/defaults/main.yaml
+++ b/roles/install-trex/defaults/main.yaml
@@ -1,0 +1,6 @@
+base_dir: "/opt/trex"
+trex_ver: "v2.82"
+trex_url: "https://trex-tgn.cisco.com/trex/release"
+force_install: False
+enable_ssl: no
+

--- a/roles/install-trex/tasks/main.yaml
+++ b/roles/install-trex/tasks/main.yaml
@@ -1,0 +1,29 @@
+---
+- name: TRex installation
+  block:
+    - name: Ensure trex base dir exists
+      file:
+        path: "{{ base_dir }}"
+        state: directory
+
+    - name: Remove trex dir
+      file:
+        path: "{{ base_dir }}/{{ trex_ver }}"
+        state: absent
+      when: force_install
+
+    - name: Unarchive trex file
+      unarchive:
+        src: "{{ trex_url }}/{{ trex_ver }}.tar.gz"
+        dest: "{{ base_dir }}"
+        remote_src: yes
+        validate_certs: "{{ enable_ssl }}"
+
+    - name: Create symlink for trex installation
+      file:
+        src: "{{ base_dir }}/{{ trex_ver }}"
+        dest: "{{ base_dir }}/current"
+        state: link
+        force: yes
+
+  become: true


### PR DESCRIPTION
Add Trex install role as an alternative to the bash script.
Less code to maintain and more testable code.